### PR TITLE
Fix typo in Dockerfile: NPM_REGISTY -> NPM_REGISTRY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18.10.0-alpine as stage-web-build
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 RUN apk add --no-cache make
 ARG NPM_REGISTRY="https://registry.npmmirror.com"
-ENV NPM_REGISTY=$NPM_REGISTRY
+ENV NPM_REGISTRY=$NPM_REGISTRY
 
 LABEL stage=stage-web-build
 RUN set -ex \


### PR DESCRIPTION
The environment variable name contains a typo and should be .

Although the registry is already configured via ,
fixing the variable name improves correctness and consistency.

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
